### PR TITLE
Move version to about us section

### DIFF
--- a/app/src/main/java/com/gemwallet/android/features/settings/aboutus/views/AboutUsScreen.kt
+++ b/app/src/main/java/com/gemwallet/android/features/settings/aboutus/views/AboutUsScreen.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.settings.aboutus.views
 
 import android.content.pm.PackageManager
 import android.os.Build
+import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.material3.HorizontalDivider
@@ -27,12 +28,17 @@ fun AboutUsScreen(
     onCancel: () -> Unit
 ) {
     val viewModel: AboutUsViewModel = hiltViewModel()
+    val context = LocalContext.current
 
     AboutUsScene(
         onCancel = onCancel,
-        onDevelopEnable = viewModel::developEnable
+        onDevelopEnable = {
+            val developer = context.getString(R.string.settings_developer)
+            val enable = context.getString(R.string.settings_enable_value, developer)
+            Toast.makeText(context, enable, Toast.LENGTH_SHORT).show()
+            viewModel.developEnable()
+        }
     )
-
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/java/com/gemwallet/android/features/settings/aboutus/views/AboutUsScreen.kt
+++ b/app/src/main/java/com/gemwallet/android/features/settings/aboutus/views/AboutUsScreen.kt
@@ -1,8 +1,20 @@
 package com.gemwallet.android.features.settings.aboutus.views
 
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.gemwallet.android.R
 import com.gemwallet.android.features.settings.settings.components.LinkItem
 import com.gemwallet.android.ui.components.open
@@ -14,7 +26,31 @@ import uniffi.gemstone.PublicUrl
 fun AboutUsScreen(
     onCancel: () -> Unit
 ) {
+    val viewModel: AboutUsViewModel = hiltViewModel()
+
+    AboutUsScene(
+        onCancel = onCancel,
+        onDevelopEnable = viewModel::developEnable
+    )
+
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun AboutUsScene(
+    onCancel: () -> Unit,
+    onDevelopEnable: () -> Unit,
+) {
     val uriHandler = LocalUriHandler.current
+    val context = LocalContext.current
+    val version = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        context.packageManager.getPackageInfo(
+            context.packageName,
+            PackageManager.PackageInfoFlags.of(0)
+        )
+    } else {
+        context.packageManager.getPackageInfo(context.packageName, 0)
+    }.versionName
     Scene(title = stringResource(id = R.string.settings_aboutus), onClose = onCancel) {
         LinkItem(title = stringResource(id = R.string.settings_privacy_policy)) {
             uriHandler.open(Config().getPublicUrl(PublicUrl.PRIVACY_POLICY))
@@ -22,5 +58,21 @@ fun AboutUsScreen(
         LinkItem(title = stringResource(id = R.string.settings_terms_of_services)) {
             uriHandler.open(Config().getPublicUrl(PublicUrl.TERMS_OF_SERVICE))
         }
+        HorizontalDivider(modifier = Modifier, thickness = 0.4.dp)
+        LinkItem(
+            title = stringResource(id = R.string.settings_version),
+            icon = R.drawable.settings_version,
+            trailingContent = {
+                Text(
+                    modifier = Modifier.combinedClickable(
+                        onClick = {},
+                        onLongClick = onDevelopEnable
+                    ),
+                    text = "${stringResource(id = R.string.settings_version)}: $version",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        ) {}
     }
 }

--- a/app/src/main/java/com/gemwallet/android/features/settings/aboutus/views/AboutUsViewModel.kt
+++ b/app/src/main/java/com/gemwallet/android/features/settings/aboutus/views/AboutUsViewModel.kt
@@ -1,0 +1,17 @@
+package com.gemwallet.android.features.settings.aboutus.views
+
+import androidx.lifecycle.ViewModel
+import com.gemwallet.android.data.repositoreis.config.UserConfig
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AboutUsViewModel @Inject constructor(
+    private val userConfig: UserConfig,
+) : ViewModel() {
+
+    fun developEnable() {
+        userConfig.developEnabled(!userConfig.developEnabled())
+    }
+
+}

--- a/app/src/main/java/com/gemwallet/android/features/settings/aboutus/views/AboutUsViewModel.kt
+++ b/app/src/main/java/com/gemwallet/android/features/settings/aboutus/views/AboutUsViewModel.kt
@@ -1,8 +1,10 @@
 package com.gemwallet.android.features.settings.aboutus.views
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.data.repositoreis.config.UserConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -10,8 +12,8 @@ class AboutUsViewModel @Inject constructor(
     private val userConfig: UserConfig,
 ) : ViewModel() {
 
-    fun developEnable() {
-        userConfig.developEnabled(!userConfig.developEnabled())
+    fun developEnable() = viewModelScope.launch {
+        userConfig.turnDevelopEnabled()
     }
 
 }

--- a/app/src/main/java/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.settings.settings.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gemwallet.android.cases.device.GetDeviceIdCase
 import com.gemwallet.android.cases.device.GetPushEnabledCase
 import com.gemwallet.android.cases.device.GetPushTokenCase
@@ -48,6 +49,7 @@ class SettingsViewModel @Inject constructor(
             }
         }
         refresh()
+        observeDevelop()
     }
 
     fun refresh() {
@@ -55,10 +57,21 @@ class SettingsViewModel @Inject constructor(
             it.copy(
                 currency = sessionRepository.getSession()?.currency ?: Currency.USD,
                 pushEnabled = getPushEnabledCase.getPushEnabled(),
-                developEnabled = userConfig.developEnabled(),
                 deviceId = getDeviceIdCase.getDeviceId(),
                 pushToken = getPushTokenCase.getPushToken()
             )
+        }
+    }
+
+    private fun observeDevelop() {
+        viewModelScope.launch {
+            userConfig.isDevelopEnabled.collect { value ->
+                state.update {
+                    it.copy(
+                        developEnabled = value
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModel.kt
@@ -50,7 +50,7 @@ class SettingsViewModel @Inject constructor(
         refresh()
     }
 
-    private fun refresh() {
+    fun refresh() {
         state.update {
             it.copy(
                 currency = sessionRepository.getSession()?.currency ?: Currency.USD,
@@ -60,11 +60,6 @@ class SettingsViewModel @Inject constructor(
                 pushToken = getPushTokenCase.getPushToken()
             )
         }
-    }
-
-    fun developEnable() {
-        userConfig.developEnabled(!userConfig.developEnabled())
-        refresh()
     }
 
     fun notificationEnable() {

--- a/app/src/main/java/com/gemwallet/android/features/settings/settings/views/SettingsScene.kt
+++ b/app/src/main/java/com/gemwallet/android/features/settings/settings/views/SettingsScene.kt
@@ -2,13 +2,10 @@ package com.gemwallet.android.features.settings.settings.views
 
 import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,10 +14,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -52,7 +48,6 @@ import uniffi.gemstone.PublicUrl
 import uniffi.gemstone.SocialUrl
 import java.util.Locale
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SettingsScene(
     onSecurity: () -> Unit,
@@ -69,11 +64,6 @@ fun SettingsScene(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val reviewManager = remember { ReviewManager(context) }
-    val version = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        context.packageManager.getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0))
-    } else {
-        context.packageManager.getPackageInfo(context.packageName, 0)
-    }.versionName
 
     val uriHandler = LocalUriHandler.current
     var requestPushGrant by remember {
@@ -161,7 +151,7 @@ fun SettingsScene(
                 onBridges()
             }
             HorizontalDivider(modifier = Modifier, thickness = 0.4.dp)
-            
+
             SubheaderItem(title = stringResource(id = R.string.settings_community))
             LinkItem(title = stringResource(id = R.string.social_x), icon = R.drawable.twitter) {
                 uriHandler.open(Config().getSocialUrl(SocialUrl.X) ?: "")
@@ -209,21 +199,6 @@ fun SettingsScene(
                     onDevelop()
                 }
             }
-            LinkItem(
-                title = stringResource(id = R.string.settings_version),
-                icon = R.drawable.settings_version,
-                trailingContent = {
-                    Text(
-                        modifier = Modifier.combinedClickable(
-                            onClick = {},
-                            onLongClick = viewModel::developEnable
-                        ),
-                        text = "${stringResource(id = R.string.settings_version)}: $version",
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-            ) {}
             Spacer16()
         }
     }

--- a/app/src/main/java/com/gemwallet/android/features/settings/settings/views/SettingsScene.kt
+++ b/app/src/main/java/com/gemwallet/android/features/settings/settings/views/SettingsScene.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/data/repositories/build.gradle.kts
+++ b/data/repositories/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
         exclude(group = "com.jakewharton.timber", module = "timber")
     }
     api(libs.walletconnect.web3wallet)
+    api(libs.datastore)
 
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ material3AdaptiveAndroid = "1.0.0-alpha06"
 turbine = "1.1.0"
 protobuf = "4.27.2"
 reorderable = "2.3.3"
+datastore = "1.1.1"
 
 [libraries]
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
@@ -76,6 +77,9 @@ compose-material3-window-size = { module = "androidx.compose.material3:material3
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+
+#Data store
+datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
 #Google play review and notifications
 play-review = { module = "com.google.android.play:review", version.ref = "review" }


### PR DESCRIPTION
The version name moved under About Us section
The developer option setting have been migrated to the datastore to support the flow and a newer API! 
Proposal: In the future, migrate all settings to the datastore + refactoring of settings ViewModel.

<img width="412" alt="Screenshot 2024-12-05 at 15 54 32" src="https://github.com/user-attachments/assets/72c7d528-35cf-43f0-b1c0-969ae1890801">
