### PR TITLE
Add MobSF mobsfscan static analysis integration

### DIFF
--- a/.github/workflows/mobsfscan.yml
+++ b/.github/workflows/mobsfscan.yml
@@ -1,0 +1,48 @@
+name: MobSF Scan
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  mobsfscan:
+    name: mobsfscan static analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install mobsfscan
+        run: uv tool install mobsfscan
+
+      - name: Run mobsfscan
+        run: |
+          set +e
+          uv tool run mobsfscan -- --type android --config .mobsf --sarif --output results.sarif --exit-warning
+          EXIT_CODE=$?
+          echo "MOBSF_EXIT=${EXIT_CODE}" >> "$GITHUB_ENV"
+          exit 0
+
+      - name: Upload mobsfscan SARIF
+        if: always() && hashFiles('results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Fail when mobsfscan finds issues
+        if: ${{ env.MOBSF_EXIT != '' && env.MOBSF_EXIT != '0' }}
+        run: |
+          echo "mobsfscan reported security findings. Review the SARIF upload for details."
+          exit 1

--- a/.mobsf
+++ b/.mobsf
@@ -1,0 +1,14 @@
+---
+- ignore-paths:
+  - build
+  - .gradle
+  - app/build
+  - blockchain/build
+  - features/build
+  - ui/build
+  - ui-models/build
+  - data/build
+  - core
+  severity-filter:
+  - WARNING
+  - ERROR

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ gpr.token=<your-github-personal-token>
 
 Optionally, you can generate models and kotlin bindgen by running `just generate`, Gem Android consumes wallet core library as a local module, if you need to update it, ping us or create an issue on [here](https://github.com/gemwalletcom/wallet-core-release).
 
+## 🔐 Security Scanning
+
+We run [MobSF mobsfscan](https://github.com/MobSF/mobsfscan) to catch insecure patterns in our Kotlin/Java sources.
+
+- **Local usage**: Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/) and run `uv tool install mobsfscan` once. After that, `just mobsfscan` (internally `uv tool run mobsfscan -- --type android --config .mobsf --exit-warning`) scans the Android codebase with the repo-wide configuration and fails on `WARNING` and `ERROR` findings.
+- **CI enforcement**: `.github/workflows/mobsfscan.yml` runs the same command on every push/PR to `main`, uploads a SARIF report to GitHub code scanning, and fails the workflow if issues remain.
+
+Only suppress detections when you fully understand the risk—ideally fix the code; otherwise, add a targeted `// mobsf-ignore: rule_id` comment with context.
+
 ## 👨‍👧‍👦 Contributors
 
 We love contributors! Feel free to contribute to this project but please read the [Contributing Guidelines](CONTRIBUTING.md) first!

--- a/justfile
+++ b/justfile
@@ -24,6 +24,12 @@ build-test:
 test:
     @./gradlew connectedGoogleDebugAndroidTest
 
+mobsfscan:
+    @command -v uv >/dev/null || { \
+        echo "uv is not installed. Install it via 'curl -LsSf https://astral.sh/uv/install.sh | sh'."; \
+        exit 1; }
+    uv tool run mobsfscan -- --type android --config .mobsf --exit-warning
+
 unsigned-release:
     SKIP_SIGN=true ./gradlew :app:bundleGoogleRelease
 


### PR DESCRIPTION
Introduces MobSF mobsfscan for static security scanning of Android code. Adds a GitHub Actions workflow for CI enforcement, a .mobsf configuration file, a 'just mobsfscan' command for local use, and updates the README with instructions and security scanning policy.