### PR TITLE
Remove ML Kit barcode scanning dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ activityCompose = "1.12.2"
 browser = "1.9.0"
 uiautomator = "2.3.0"
 walletconnect = "1.5.2"
-barcodeScanning = "17.3.0"
 biometric = "1.2.0-alpha05"
 cameraCamera2 = "1.5.2"
 coilCompose = "3.3.0"
@@ -125,7 +124,6 @@ gemstone = { module = "com.gemwallet.gemstone:gemstone", version.ref = "gemstone
 
 # qr code scanning
 zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "barcodeScanning" }
 camera-view = { module = "androidx.camera:camera-view", version.ref = "cameraCamera2" }
 camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "cameraCamera2" }
 camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "cameraCamera2" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -72,7 +72,6 @@ dependencies {
     implementation(libs.camera.camera2)
     implementation(libs.camera.lifecycle)
     implementation(libs.camera.view)
-    implementation(libs.barcode.scanning)
     // QR Code
     api(libs.zxing.core)
 


### PR DESCRIPTION
Eliminated the Google ML Kit barcode scanning library from the project dependencies and version catalog. This streamlines dependencies and may indicate a shift to alternative QR/barcode scanning solutions.